### PR TITLE
Template for PRACTICES.md

### DIFF
--- a/PRACTICES-template.md
+++ b/PRACTICES-template.md
@@ -9,6 +9,9 @@ Any one of these categories could be a great topic for a PSIP PTC.
 - Policies
   - location:
   - decision making process:
+  - PI:
+  - maintainer contact:
+  - code of conduct:
 - Version Tracking Practices
   - Official source location:
   - Source management system:

--- a/PRACTICES-template.md
+++ b/PRACTICES-template.md
@@ -34,3 +34,6 @@ Any one of these categories could be a great topic for a PSIP PTC.
 - Citation Practicies:
   - Official citation:
   - Authorship contributions:
+- Development Practices:
+  - Task assignment:
+  - Task tracking:

--- a/PRACTICES-template.md
+++ b/PRACTICES-template.md
@@ -1,42 +1,53 @@
 # Software Development Practices
 
-This document could potentially go into the repo itself, possibly within the `.github` folder. Its purpose is to document *current* practices of the development team. By having it version controlled the practices can change over time.
+This document could potentially go into the repo itself, possibly within the `.github` folder. Its purpose is to document *current* practices of the project and development team. By having it under version control, these practices can change over time.
 
-The following is loosely in a yaml format: each top-level bullet containins a sub-list of key-value items. This is just a starter list, items and categories should be added or removed to suit each individual project. Reviewing and updating the list can be an excellent on-boarding activity.
+The following is in markdown format: categories are shown as 2nd level headings, details are lists of key-value-style pairs. This is just a starter list, items and categories should be added or removed to suit each individual project. Reviewing and updating the list can be an excellent on-boarding activity. Many of these items would be a great topic for a PSIP PTC.
 
-Any one of these categories could be a great topic for a PSIP PTC.
+## High-Level Policies
 
-- Policies
-  - location:
-  - decision making process:
-  - PI:
-  - maintainer contact:
-  - code of conduct:
-- Version Tracking Practices
+*This category contains high-level project information.*
+
+  - PI: <lead for the project>
+  - Maintainers contact: <preferred way to get in touch with maintainers>
+  - Issue Reporting: <preferred way to report issues>
+  - Decision making process: <details on how decisions are made>
+  - Code of conduct: <loction or details for code-of-conduct>
+  - Contributing guide: <location>
+
+## Coding Practices
+
+*This category contains policy information around the code itself, including documentation. The information here is relevant for all contributors.*
+
+Version Tracking Practices
   - Official source location:
-  - Source management system:
-  - Release management:
-  - Workflow:
-- Documentation Practices
-  - Website:
+  - Source management system: [ git | bazar | mercurial ]
+  - Release management: <versioning details, schedule>
+  - Workflow: [ gitflow | other | see CONTRIBUTING.md ]
+  - Branch naming policy:
+
+Documentation Practices
+  - Website: 
   - User documentation:
   - Developer documentation:
-  - Documentation expectations:
-- Testing Practices:
+  - Documentation expectations: [ documentation update with each PR ]
+
+Testing Practices
   - Unit testing:
   - Continuous integration:
-- Style Practices:
-  - Style enforcement:
-  - Style policy:
-- Issue Policies: 
-  - Bug reporting system:
-  - Issue tracking system:
-- Communication Practices:
-  - Responsiveness expectations:
+
+Style Practices
+  - Style policy: <file location>
+  - Style enforcement: <by CI on PRs>
+  
+## Development Team Practices
+
+*This category is for the policies for core development team members. It includes expectations around communication and development.*
+
+Communication Practices
   - Platforms:
-- Citation Practicies:
-  - Official citation:
-  - Authorship contributions:
-- Development Practices:
+  - Responsiveness expectations:
+
+Development Practices
   - Task assignment:
   - Task tracking:


### PR DESCRIPTION
The first part of the PSIP process is documenting a team’s current practices. Teams would fill in the values and document could live in `PRACTICES.md` within the repo (possibly in the `.github` folder to prevent clutter). Teams would add/remove items as they saw fit.

Categories and starter item suggestions are welcome!

*Due to my fat fingers, I accidentially committed this document directly on the master branch. I had intended for it to be cooperatively developed in a PR before merging... oops*. 